### PR TITLE
Run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd --create-home appuser
+USER appuser
+
 EXPOSE 8080
 
 CMD ["python", "webserver.py"]


### PR DESCRIPTION
## Summary
- Adds a non-root `appuser` to the Dockerfile
- Switches to `appuser` before `EXPOSE` and `CMD` for improved container security

🤖 Generated with [Claude Code](https://claude.com/claude-code)